### PR TITLE
Updated nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
 # this configuration is contrib, if it doesn't work anymore, please fix it and submit a PR
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc8102" }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc98" }:
 nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./lattices.nix { }

--- a/lattices.nix
+++ b/lattices.nix
@@ -1,27 +1,3 @@
 # this configuration is contrib, if it doesn't work anymore, please fix it and submit a PR
-{ mkDerivation, base, base-compat, containers, deepseq, hashable
-, integer-logarithms, QuickCheck, quickcheck-instances
-, semigroupoids, stdenv, tagged, tasty, tasty-quickcheck
-, transformers, universe-base, universe-reverse-instances
-, unordered-containers
-}:
-mkDerivation {
-  pname = "lattices";
-  version = "2.0.2";
-  sha256 = "108rhpax72j6xdl0yqdmg7n32l1j805861f3q9wd3jh8nc67avix";
-  revision = "2";
-  editedCabalFile = "085b0qn6ya4jchgk86yyvvhac1flricryibrvi4ni9kqw29dr31g";
-  libraryHaskellDepends = [
-    base base-compat containers deepseq hashable integer-logarithms
-    QuickCheck semigroupoids tagged transformers universe-base
-    universe-reverse-instances unordered-containers
-  ];
-  testHaskellDepends = [
-    base base-compat containers QuickCheck quickcheck-instances tasty
-    tasty-quickcheck transformers universe-base
-    universe-reverse-instances unordered-containers
-  ];
-  homepage = "http://github.com/phadej/lattices/";
-  description = "Fine-grained library for constructing and manipulating lattices";
-  license = stdenv.lib.licenses.bsd3;
-}
+{ haskellPackages, lib }:
+haskellPackages.callCabal2nix "lattices" (lib.cleanSource ./.)  {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,3 @@
 # this configuration is contrib, if it doesn't work anymore, please fix it and submit a PR
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc8102" }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc98" }:
 (import ./default.nix { inherit nixpkgs compiler; }).env


### PR DESCRIPTION
In the current version of nixpkgs the GHC 8.10.2 is no longer available, so I switched it to 9.8 to fix the nix build and shell definitions. I also replaced the (cabal2nix) generated build definition with an expression calling the generator, so the nix build gets automatically updated when the cabal build is changed.

It is worth noting that building directly with nix currently fails due to the Hackage metadata revisions.  